### PR TITLE
Update post cards

### DIFF
--- a/packages/knittingarch_maktub/default-post.hbs
+++ b/packages/knittingarch_maktub/default-post.hbs
@@ -141,7 +141,7 @@
             {{#get "posts" filter="id:-{{id}}+primary_tag:{{primary_tag.slug}}" limit="4" as |related-articles| }}
                 {{#if related-articles}}
                     <section class="related section" id="epcl-related-stories">
-                        <h3 class="title bordered">{{t "Related Articles"}}<span class="border"></span></h3>
+                        <h3 class="title bordered">{{t "Related Posts"}}<span class="border"></span></h3>
                         <div class="epcl-row">                        
                             {{#foreach related-articles visibility="all" columns="2"}}
                                 <article class="item grid-50 tablet-grid-50 mobile-grid-100 ctag-{{primary_tag.slug}} {{post_class}}">
@@ -174,7 +174,7 @@
             {{/get}}
 
             <section class="siblings section" id="epcl-other-stories">
-                <h3 class="title bordered">{{t "Other Stories"}}<span class="border"></span></h3>
+                <h3 class="title bordered">{{t "Other Posts"}}<span class="border"></span></h3>
                 {{#prev_post}}
                     <article class="prev bg-white">
                         {{#if feature_image}}

--- a/packages/knittingarch_maktub/default-post.hbs
+++ b/packages/knittingarch_maktub/default-post.hbs
@@ -35,9 +35,11 @@
                         </div>
                     {{else}}
                         <div class="post-style-text epcl-flex ctag-{{primary_tag.slug}}">
+                            <!-- TODO: Figure out how to make this less obtrusive 
                                 <div class="epcl-dropcap">
                                     <span class="first-letter" data-title="{{title}}"></span>
                                 </div>
+                            -->
                             <div class="info">    
                                 <h1 class="main-title title large">{{title}}</h1>
                                 <!-- start: .meta -->
@@ -62,6 +64,7 @@
                     {{/if}}
 
                     <div class="clear"></div>
+
 
                 </header>
 
@@ -103,11 +106,13 @@
             </article>
             <div class="clear"></div>
 
-            {{#primary_author}}
-                {{> author-box }}
-            {{/primary_author}}
+            {{!--
+                {{#primary_author}}
+                    {{> author-box }}
+                {{/primary_author}}
+            --}}
 
-            <div class="clear"></div>
+            <!-- <div class="clear"></div> -->
 
             {{#if @custom.disqus_shortname}}
                 <!-- start: disqus integration -->
@@ -145,10 +150,13 @@
                                         <span class="fullimage cover lazy" data-src="{{img_url feature_image size="thumbnail"}}"></span>
                                         <span class="fullimage cover lazy fake-layout" data-src="{{img_url feature_image size="thumbnail"}}"></span>
                                     </a>
+                                    <!-- TODO: Figure out how to make this less obtrusive -->
+                                    {{!--
                                     {{else}}
                                         <a class="epcl-dropcap large main-effect text-only" href="{{url}}">
                                             <span class="first-letter fake-layout" data-title="{{title}}"></span>
                                         </a>
+                                    --}}
                                     {{/if}}
                                     <div class="info">
                                         <h4 class="title small no-margin underline-effect"><a href="{{url}}">{{title}}</a></h4>
@@ -173,10 +181,13 @@
                             <div class="thumb epcl-dropcap epcl-loader">
                                 <span class="fullimage cover lazy" data-src="{{img_url feature_image size="thumbnail"}}"></span>
                             </div>
+                        <!-- TODO: Figure out how to make this less obtrusive -->
+                        {{!--
                         {{else}}
                             <div class="thumb epcl-dropcap">
                                 <span class="first-letter" data-title="{{title}}"></span>
                             </div>
+                        --}}
                         {{/if}}
                         <a href="{{url}}" class="full-link"></a>
                         <div class="info">

--- a/packages/knittingarch_maktub/partials/demo/footer.hbs
+++ b/packages/knittingarch_maktub/partials/demo/footer.hbs
@@ -6,7 +6,7 @@
 
             <!-- start: .recent-articles -->
             <div class="widget widget_epcl_posts_thumbs grid-25 tablet-grid-50 mobile-grid-100">
-                <h4 class="widget-title title medium bordered"><span class="bg">{{t "Latest Articles" }}</span><span class="border"></span></h4>
+                <h4 class="widget-title title medium bordered"><span class="bg">{{t "Latest Posts" }}</span><span class="border"></span></h4>
                 {{#get "posts" limit="3" include="tags" as |recent-articles| }}
                     {{#foreach recent-articles visibility="all"}}
                         <article class="{{post_class}} item ctag-{{primary_tag.slug}} no-thumb">

--- a/packages/knittingarch_maktub/partials/demo/sidebar.hbs
+++ b/packages/knittingarch_maktub/partials/demo/sidebar.hbs
@@ -3,7 +3,7 @@
 
     <!-- start: .recent-articles -->
     <div class="widget widget_epcl_posts_thumbs grid-25 tablet-grid-50 mobile-grid-100">
-        <h4 class="widget-title title medium bordered"><span class="bg">{{t "Latest Articles" }}</span><span class="border"></span></h4>
+        <h4 class="widget-title title medium bordered"><span class="bg">{{t "Latest Posts" }}</span><span class="border"></span></h4>
         {{#get "posts" limit="3" include="tags" as |recent-articles| }}
             {{#foreach recent-articles visibility="all"}}
                 <article class="{{post_class}} item ctag-{{primary_tag.slug}} no-thumb">

--- a/packages/knittingarch_maktub/partials/loop/classic-article.hbs
+++ b/packages/knittingarch_maktub/partials/loop/classic-article.hbs
@@ -15,7 +15,8 @@
                         {{/if}}           
                     </a>
                 <!-- TODO: Figure out how to make this less obtrusive -->
-                {{!-- {{else}}
+                {!--
+                {{else}}
                     <a class="epcl-dropcap main-effect text-only" href="{{url}}">
                         <span class="first-letter fake-layout" data-title="{{title}}"></span>
                     </a>

--- a/packages/knittingarch_maktub/partials/loop/classic-article.hbs
+++ b/packages/knittingarch_maktub/partials/loop/classic-article.hbs
@@ -102,6 +102,7 @@
             </div>
         {{/if}}         
         
+        <!--
         <div class="meta bottom">
             {{#foreach authors limit="1" }}
                 <a href="{{url}}" title="{{name}}" class="author meta-info hide-on-mobile">                                        
@@ -116,6 +117,7 @@
                 </a>
             {{/foreach}}
         </div>
+        -->
         
         <div class="clear"></div>
 

--- a/packages/knittingarch_maktub/partials/loop/classic-article.hbs
+++ b/packages/knittingarch_maktub/partials/loop/classic-article.hbs
@@ -15,7 +15,7 @@
                         {{/if}}           
                     </a>
                 <!-- TODO: Figure out how to make this less obtrusive -->
-                {!--
+                {{!--
                 {{else}}
                     <a class="epcl-dropcap main-effect text-only" href="{{url}}">
                         <span class="first-letter fake-layout" data-title="{{title}}"></span>

--- a/packages/knittingarch_maktub/partials/loop/classic-article.hbs
+++ b/packages/knittingarch_maktub/partials/loop/classic-article.hbs
@@ -96,7 +96,7 @@
                 
         {{#if tags}}               
             <div class="tags">
-                {{#foreach tags visibility="public" limit="3"}}
+                {{#foreach tags visibility="public" limit="all"}}
                     <a href="{{url}}" class="ctag ctag-{{slug}}" data-id="ctag-{{slug}}">{{name}}</a>
                 {{/foreach}}
             </div>

--- a/packages/knittingarch_maktub/partials/loop/grid-article.hbs
+++ b/packages/knittingarch_maktub/partials/loop/grid-article.hbs
@@ -14,7 +14,8 @@
                             {{/if}}   
                         </a>
                     <!-- TODO: Figure out how to make this less obtrusive -->
-                    {{!-- {{else}}
+                    {{!--
+                    {{else}}
                         <a class="epcl-dropcap large main-effect text-only" href="{{url}}">
                             <span class="first-letter fake-layout" data-title="{{title}}"></span>
                         </a>

--- a/packages/knittingarch_maktub/partials/widgets/recent-articles.hbs
+++ b/packages/knittingarch_maktub/partials/widgets/recent-articles.hbs
@@ -1,6 +1,6 @@
 <!-- start: .recent-articles -->
 <div class="widget widget_epcl_posts_thumbs grid-25 tablet-grid-50 mobile-grid-100">
-    <h4 class="widget-title title medium bordered"><span class="bg">{{t "Latest Articles" }}</span><span class="border"></span></h4>
+    <h4 class="widget-title title medium bordered"><span class="bg">{{t "Latest Posts" }}</span><span class="border"></span></h4>
     {{#get "posts" limit="3" include="tags" as |recent-articles| }}
         {{#foreach recent-articles visibility="all"}}
             <article class="{{post_class}} item ctag-{{primary_tag.slug}} {{^if feature_image}}no-thumb{{/if}}">

--- a/packages/knittingarch_maktub/tag.hbs
+++ b/packages/knittingarch_maktub/tag.hbs
@@ -9,7 +9,7 @@
             <div class="tag-description section">
                 <div class="left grid-35 tablet-grid-45 np-mobile">
                     <h1 class="title large fw-semibold no-margin ctag-{{slug}}">{{name}}</h1>
-                    <div class="total">{{plural ../pagination.total empty=(t "0  Articles") singular=(t "1 Article") plural=(t "% Articles")}}</div>
+                    <div class="total">{{plural ../pagination.total empty=(t "0  Posts") singular=(t "1 Post") plural=(t "% Posts")}}</div>
                     <div class="epcl-decoration-counter">{{../pagination.total}}</div>
                 </div>
                 {{#if description}}


### PR DESCRIPTION
**The Work**

- Remove author by-line from truncated post card
- All all tags to be visible on truncated post card
- Update copy to use `post` instead of `article` or `stories`
- Remove additional drop caps